### PR TITLE
[flo-362:go-core] Stop asking Bugsnag to handle panics.

### DIFF
--- a/log/bugsnag_logger.go
+++ b/log/bugsnag_logger.go
@@ -29,6 +29,7 @@ func NewBugsnagConfig(version, env, apiKey string) *BugsnagConfig {
 			ReleaseStage:        env,
 			AppVersion:          version,
 			NotifyReleaseStages: []string{"production"},
+			PanicHandler:        func() {},
 		})
 		reportable = true
 	}


### PR DESCRIPTION
Bugsnag handles panics by restarting your program and watching the new
instance's stderr for the word "panic: ". Additionally, it closes stderr
when it receives a SIGINT, making it difficult to gracefully shut down.
I was unable to ensure a graceful shutdown could happen in any of our
apps when using bugsnag's panic handling.

Moving forward, we should handle our own panics and monitor our logs for
panics.